### PR TITLE
django_ynh -> django in manifest ..?

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-	"name": "django_ynh",
-	"id": "django_ynh",
+	"name": "Django",
+	"id": "django",
 	"packaging_format": 1,
 	"description": {
 		"en": "Glue code to package django projects as yunohost apps."
@@ -26,8 +26,8 @@
 				"name": "domain",
 				"type": "domain",
 				"ask": {
-					"en": "Choose a domain for django_ynh",
-					"fr": "Choisissez un domaine pour django_ynh"
+					"en": "Choose a domain for django",
+					"fr": "Choisissez un domaine pour django"
 				},
 				"example": "domain.org"
 			},
@@ -35,18 +35,18 @@
 				"name": "path",
 				"type": "path",
 				"ask": {
-				    "en": "Choose a path for django_ynh",
-				    "fr": "Choisissez un chemin pour django_ynh"
+				    "en": "Choose a path for django",
+				    "fr": "Choisissez un chemin pour django"
 				},
-				"example": "/django_ynh",
-				"default": "/django_ynh"
+				"example": "/django",
+				"default": "/django"
 			},
 			{
 				"name": "admin",
 				"type": "user",
 				"ask": {
-				    "en": "Choose an admin user for django_ynh",
-				    "fr": "Choisissez l'administrateur pour django_ynh"
+				    "en": "Choose an admin user for django",
+				    "fr": "Choisissez l'administrateur pour django"
 				},
 				"example": "johndoe"
 			},
@@ -54,8 +54,8 @@
 				"name": "is_public",
 				"type": "boolean",
 				"ask": {
-					"en": "Should django_ynh be public accessible?",
-					"fr": "django_ynh doit-il être accessible au public ?"
+					"en": "Should django be public accessible?",
+					"fr": "django doit-il être accessible au public ?"
 				},
 				"help": {
 					"en": "Any YunoHost user and anonymous people from the web will be able to access the application",


### PR DESCRIPTION
It's a bit confusing that the id of the app is foobar_ynh ... this is a yunohost app so "of course" it's a ... yunohost app ... The convention is just that only the name of the git repo is prefixed with _ynh